### PR TITLE
Revert Merged pull request #17 #16 #7 #15 #14 #13 #12

### DIFF
--- a/hms-lambda-func/pom.xml
+++ b/hms-lambda-func/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.6.1</version>
+            <version>2.9.10.5</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/hms-lambda-handler/pom.xml
+++ b/hms-lambda-handler/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.6.1</version>
+            <version>2.9.10.5</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/hms-lambda-layer/pom.xml
+++ b/hms-lambda-layer/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.6.1</version>
+            <version>2.9.10.5</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javac.target>1.8</javac.target>
     <hive.version>2.3.4</hive.version>
-    <hadoop.version>2.10.1</hadoop.version>
+    <hadoop.version>2.7.4</hadoop.version>
     <commons-cli.version>1.4</commons-cli.version>
   </properties>
 
@@ -170,7 +170,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.7</version>
+        <version>2.4</version>
       </dependency>
       <dependency>
         <groupId>commons-configuration</groupId>
@@ -200,7 +200,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.13.1</version>
+        <version>4.11</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Revert "Merge pull request #17 from aws-samples/dependabot/maven/commons-io-commons-io-2.7"

This reverts commit 0e7e061f49d5cafac630379bc0f67a35c282f5fd, reversing
changes made to 30a0b7b1af1846f296f9f4a4d3b9008a8287eecc.

Revert "Merge pull request #16 from aws-samples/dependabot/maven/org.apache.hadoop-hadoop-common-2.10.1"

This reverts commit 30a0b7b1af1846f296f9f4a4d3b9008a8287eecc, reversing
changes made to a169bbd3ae6e4ba842a8e69f49185b71517a11f2.

Revert "Merge pull request #7 from aws-samples/dependabot/maven/junit-junit-4.13.1"

This reverts commit a169bbd3ae6e4ba842a8e69f49185b71517a11f2, reversing
changes made to 82fd8b7c4060c45bab24e73dbff1cc71e53263d3.

Revert "Merge pull request #15 from aws-samples/dependabot/maven/hms-lambda-func/com.fasterxml.jackson.core-jackson-databind-2.12.6.1"

This reverts commit 82fd8b7c4060c45bab24e73dbff1cc71e53263d3, reversing
changes made to b07048c049b567a9400b3dc8c97aeb5e3cd47447.

Revert "Merge pull request #14 from aws-samples/dependabot/maven/hms-lambda-handler/com.fasterxml.jackson.core-jackson-databind-2.12.6.1"

This reverts commit b07048c049b567a9400b3dc8c97aeb5e3cd47447, reversing
changes made to 104bc848b18e6058d719e10f1f61eb7f97393a38.

Revert "Merge pull request #13 "
This reverts commit 104bc848b18e6058d719e10f1f61eb7f97393a38, reversing
changes made to d13d56d11e5d4a9dc571f4f44aa6d8a68969ada8.

Revert "Merge pull request #12 from aws-samples/dependabot/maven/hms-lambda-layer/com.fasterxml.jackson.core-jackson-databind-2.9.10.8"

This reverts commit d13d56d11e5d4a9dc571f4f44aa6d8a68969ada8, reversing
changes made to feae3916cc4b05f56c7cc7d8830a07dd7f8f8fc6.
