### PR TITLE
Dependency updates

### DIFF
--- a/hms-lambda-func/pom.xml
+++ b/hms-lambda-func/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.5</version>
+            <version>2.12.6.1</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/hms-lambda-func/pom.xml
+++ b/hms-lambda-func/pom.xml
@@ -70,6 +70,16 @@
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-annotations</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <exclusions>
                 <exclusion>
@@ -83,6 +93,11 @@
             <groupId>ch.qos.reload4j</groupId>
             <artifactId>reload4j</artifactId>
             <version>1.2.19</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.htrace</groupId>
+            <artifactId>htrace-core4</artifactId>
+            <version>4.1.0-incubating</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hive</groupId>

--- a/hms-lambda-func/pom.xml
+++ b/hms-lambda-func/pom.xml
@@ -78,6 +78,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Needed for hadoop-mapreduce-client-core -->
+        <dependency>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+            <version>1.2.19</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-metastore</artifactId>
@@ -107,8 +113,8 @@
             <artifactId>commons-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>

--- a/hms-lambda-handler/pom.xml
+++ b/hms-lambda-handler/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.5</version>
+            <version>2.12.6.1</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/hms-lambda-handler/pom.xml
+++ b/hms-lambda-handler/pom.xml
@@ -66,12 +66,12 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+        <!-- Needed for hadoop-mapreduce-client-core -->
+        <dependency>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+            <version>1.2.19</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hive</groupId>
@@ -102,8 +102,8 @@
             <artifactId>commons-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
@@ -126,6 +126,21 @@
                     <artifactId>commons-beanutils</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.0.1-jre</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>6.2.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/hms-lambda-layer/pom.xml
+++ b/hms-lambda-layer/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.5</version>
+            <version>2.12.6.1</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/hms-lambda-layer/pom.xml
+++ b/hms-lambda-layer/pom.xml
@@ -73,6 +73,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Needed for hadoop-mapreduce-client-core -->
+        <dependency>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+            <version>1.2.19</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-metastore</artifactId>
@@ -102,9 +108,10 @@
             <artifactId>commons-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
+
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,17 @@
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-annotations</artifactId>
+        <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-mapreduce-client-core</artifactId>
         <version>${hadoop.version}</version>
         <exclusions>
@@ -141,6 +152,11 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>1.7.36</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.htrace</groupId>
+        <artifactId>htrace-core4</artifactId>
+        <version>4.1.0-incubating</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javac.target>1.8</javac.target>
-    <hive.version>2.3.4</hive.version>
-    <hadoop.version>2.7.4</hadoop.version>
+    <hive.version>2.3.9</hive.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <commons-cli.version>1.4</commons-cli.version>
   </properties>
 
@@ -140,7 +140,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.10</version>
+        <version>1.7.36</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
@@ -148,14 +148,14 @@
         <version>1.2</version>
       </dependency>
       <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>1.2.17</version>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>2.17.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-1.2-api</artifactId>
-        <version>2.6.2</version>
+        <version>2.17.2</version>
       </dependency>
       <dependency>
         <groupId>com.lmax</groupId>
@@ -200,7 +200,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>4.13.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
This change updates Hive, Hadoop, Jackson databind, and Log4J versions which have known vulnerabilities