### PR TITLE
Implementing partition filtering for getPartitions

### DIFF
--- a/hms-lambda-func/src/main/java/com/amazonaws/athena/hms/ThriftHiveMetaStoreClient.java
+++ b/hms-lambda-func/src/main/java/com/amazonaws/athena/hms/ThriftHiveMetaStoreClient.java
@@ -308,6 +308,11 @@ public class ThriftHiveMetaStoreClient implements HiveMetaStoreClient
     return client.get_partitions(dbName, tableName, maxSize);
   }
 
+  public List<Partition> getPartitionsByFilter(String dbName, String tableName, String partitionFilter, short maxSize) throws TException
+  {
+    return client.get_partitions_by_filter(dbName, tableName, partitionFilter, maxSize);
+  }
+
   public DropPartitionsResult dropPartitions(String dbName, String tableName,
                                              List<String> partNames) throws TException
   {

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/HiveMetaStoreClient.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/HiveMetaStoreClient.java
@@ -80,6 +80,8 @@ public interface HiveMetaStoreClient
 
   List<Partition> getPartitions(String dbName, String tableName, short maxSize) throws TException;
 
+  List<Partition> getPartitionsByFilter(String dbName, String tableName, String partitionFilter, short maxSize) throws TException;
+
   DropPartitionsResult dropPartitions(String dbName, String tableName,
                                       List<String> partNames) throws TException;
 

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetPartitionsHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetPartitionsHandler.java
@@ -46,8 +46,14 @@ public class GetPartitionsHandler extends BaseHMSHandler<GetPartitionsRequest, G
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
       HiveMetaStoreClient client = getClient();
       context.getLogger().log("Fetching partitions for DB: " + request.getDbName() + ", table: " + request.getTableName());
-      List<Partition> partitionList =
-          client.getPartitions(request.getDbName(), request.getTableName(), request.getMaxSize());
+      List<Partition> partitionList;
+      if (request.getPartitionExpression() != null) {
+        partitionList = client.getPartitionsByFilter(request.getDbName(), request.getTableName(),
+                request.getPartitionExpression(), request.getMaxSize());
+      }
+      else {
+        partitionList = client.getPartitions(request.getDbName(), request.getTableName(), request.getMaxSize());
+      }
       context.getLogger().log("Fetched partitions: " + (partitionList == null || partitionList.isEmpty() ? 0 : partitionList.size()));
       GetPartitionsResponse response = new GetPartitionsResponse();
       if (partitionList != null && !partitionList.isEmpty()) {

--- a/hms-service-api/src/main/java/com/amazonaws/athena/hms/GetPartitionsRequest.java
+++ b/hms-service-api/src/main/java/com/amazonaws/athena/hms/GetPartitionsRequest.java
@@ -23,6 +23,7 @@ public class GetPartitionsRequest extends ApiRequest
 {
   private String dbName;
   private String tableName;
+  private String partitionExpression;
   // default value "-1" means unlimited
   private short maxSize = -1;
 
@@ -46,6 +47,16 @@ public class GetPartitionsRequest extends ApiRequest
     this.tableName = tableName;
   }
 
+  public String getPartitionExpression()
+  {
+    return partitionExpression;
+  }
+
+  public void setPartitionExpression(String partitionExpression)
+  {
+    this.partitionExpression = partitionExpression;
+  }
+
   public short getMaxSize()
   {
     return maxSize;
@@ -65,6 +76,12 @@ public class GetPartitionsRequest extends ApiRequest
   public GetPartitionsRequest withTableName(String tableName)
   {
     this.tableName = tableName;
+    return this;
+  }
+
+  public GetPartitionsRequest withPartitionExpression(String partitionExpression)
+  {
+    this.partitionExpression = partitionExpression;
     return this;
   }
 


### PR DESCRIPTION
Athena has implemented the functionality to pass partition filter expressions into the EHMS Lambda client which allow the Client to pass back fewer partitions. This will help to improve performance as we currently load all partitions from the Hive client and filter them locally.

Testing:
Built and deployed this client to EHMS Lambda and tested tables with and without the partition filtering enabled.

Tested the API request in Lambda separately with this JSON to validate that partitions are filtered: 

Example JSON request:

{
  "apiName": "getPartitions",
  "apiRequest": {
     "dbName": "default",
     "tableName": "test_partitioned_table",
     "partitionExpression": "year = '2020' and month >= '07' and day < '10'"
  }
}


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
