### PR TITLE
force paginated response to list-databases API

### DIFF
--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/ListDatabasesHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/ListDatabasesHandler.java
@@ -75,6 +75,10 @@ public class ListDatabasesHandler extends BaseHMSHandler<ListDatabasesRequest, L
     HiveMetaStoreConf conf = getConf();
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
+      // force paginated response
+      if (request.getMaxSize() < (short) 0) {
+        request.setMaxSize((short) 500);
+      }
       HiveMetaStoreClient client = getClient();
       ListDatabasesResponse response = new ListDatabasesResponse();
       DatabasePaginator paginator = new DatabasePaginator(context, request, client);


### PR DESCRIPTION
When clients don't use pagination option, Athena invokes Lambda with maxPageSize = -1, which can cause timeout if there are large no. of schemas in HMS This change will forcefully send the paginated response irrespective of client size API implementation Assuming client can handle paginated response!

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
