### PR TITLE
EHMS Client Refresh Fix

### DIFF
--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/HiveMetaStoreClient.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/HiveMetaStoreClient.java
@@ -19,12 +19,18 @@
  */
 package com.amazonaws.athena.hms;
 
+import com.amazonaws.services.lambda.runtime.Context;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.DropPartitionsResult;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.thrift.TException;
 
+import javax.security.auth.login.LoginException;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -106,4 +112,7 @@ public interface HiveMetaStoreClient
 
   boolean listPartitionsByExpr(String dbName, String tableName,
                                byte[] expr, String defaultPartitionName, short maxParts, List<Partition> partitions) throws TException;
+
+  void close(Context context);
+  void refreshClient(HiveConf hiveConf, Context context) throws TException, LoginException, IOException, URISyntaxException, InterruptedException;
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/AddPartitionHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/AddPartitionHandler.java
@@ -41,9 +41,10 @@ public class AddPartitionHandler extends BaseHMSHandler<AddPartitionRequest, Add
   public AddPartitionResponse handleRequest(AddPartitionRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Creating partition with desc: " + request.getPartitionDesc());
       TDeserializer deserializer = new TDeserializer(getTProtocolFactory());
       Partition partition = new Partition();
@@ -58,8 +59,7 @@ public class AddPartitionHandler extends BaseHMSHandler<AddPartitionRequest, Add
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/AddPartitionsHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/AddPartitionsHandler.java
@@ -41,9 +41,10 @@ public class AddPartitionsHandler extends BaseHMSHandler<AddPartitionsRequest, A
   public AddPartitionsResponse handleRequest(AddPartitionsRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       boolean isEmpty = request.getPartitionDescs() == null || request.getPartitionDescs().isEmpty();
       context.getLogger().log("Adding partitions: " +
           (isEmpty ? 0 : request.getPartitionDescs().size()));
@@ -61,8 +62,7 @@ public class AddPartitionsHandler extends BaseHMSHandler<AddPartitionsRequest, A
       return new AddPartitionsResponse();
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/AlterDatabaseHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/AlterDatabaseHandler.java
@@ -39,9 +39,10 @@ public class AlterDatabaseHandler extends BaseHMSHandler<AlterDatabaseRequest, A
     public AlterDatabaseResponse handleRequest(AlterDatabaseRequest alterDatabaseRequest, Context context)
     {
         HiveMetaStoreConf conf = getConf();
+        HiveMetaStoreClient client = null;
         try {
             context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-            HiveMetaStoreClient client = getClient();
+            client = getClient();
 
             context.getLogger().log("Altering database " + alterDatabaseRequest.getDbName());
             TDeserializer deserializer = new TDeserializer(getTProtocolFactory());
@@ -54,8 +55,7 @@ public class AlterDatabaseHandler extends BaseHMSHandler<AlterDatabaseRequest, A
             return alterDatabaseResponse;
         }
         catch (Exception e) {
-            context.getLogger().log("Exception: " + e.getMessage());
-            throw new RuntimeException(e);
+            throw handleException(context, e);
         }
     }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/AlterPartitionHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/AlterPartitionHandler.java
@@ -38,9 +38,10 @@ public class AlterPartitionHandler extends BaseHMSHandler<AlterPartitionRequest,
   public AlterPartitionResponse handleRequest(AlterPartitionRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Altering partition: " + request.getPartitionDesc());
       TDeserializer deserializer = new TDeserializer(getTProtocolFactory());
       Partition partition = new Partition();
@@ -50,8 +51,7 @@ public class AlterPartitionHandler extends BaseHMSHandler<AlterPartitionRequest,
       return new AlterPartitionResponse();
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/AlterPartitionsHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/AlterPartitionsHandler.java
@@ -41,9 +41,10 @@ public class AlterPartitionsHandler extends BaseHMSHandler<AlterPartitionsReques
   public AlterPartitionsResponse handleRequest(AlterPartitionsRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       boolean isEmpty = request.getPartitionDescs() == null || request.getPartitionDescs().isEmpty();
       context.getLogger().log("Altering partitions: " +
           (isEmpty ? 0 : request.getPartitionDescs().size()));
@@ -61,8 +62,7 @@ public class AlterPartitionsHandler extends BaseHMSHandler<AlterPartitionsReques
       return new AlterPartitionsResponse();
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/AlterTableHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/AlterTableHandler.java
@@ -38,9 +38,10 @@ public class AlterTableHandler extends BaseHMSHandler<AlterTableRequest, AlterTa
   public AlterTableResponse handleRequest(AlterTableRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Altering table " + request.getTableName() + " in DB " + request.getDbName());
       TDeserializer deserializer = new TDeserializer(getTProtocolFactory());
       Table newTable = new Table();
@@ -52,8 +53,7 @@ public class AlterTableHandler extends BaseHMSHandler<AlterTableRequest, AlterTa
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/AppendPartitionHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/AppendPartitionHandler.java
@@ -36,17 +36,17 @@ public class AppendPartitionHandler extends BaseHMSHandler<AppendPartitionReques
   public AppendPartitionResponse handleRequest(AppendPartitionRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Appending partition for table " + request.getTableName() + " in DB " + request.getDbName());
       client.appendPartition(request.getDbName(), request.getTableName(), request.getPartitionValues());
       context.getLogger().log("Appended partition for table " + request.getTableName() + " in DB " + request.getDbName());
       return new AppendPartitionResponse();
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/BaseHMSHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/BaseHMSHandler.java
@@ -56,4 +56,19 @@ public abstract class BaseHMSHandler<REQUEST, RESPONSE> implements RequestHandle
 
   @Override
   public abstract RESPONSE handleRequest(REQUEST request, Context context);
+
+  public RuntimeException handleException(Context context, Exception e)
+  {
+    context.getLogger().log("Exception: " + e.getMessage());
+    context.getLogger().log("Refreshing client due to above exception");
+    if (client != null) {
+      try {
+        client.refreshClient(conf.toHiveConf(), context);
+      }
+      catch (Exception exception) {
+        context.getLogger().log("Exception during client refresh: " + exception.getMessage());
+      }
+    }
+    return new RuntimeException(e);
+  }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/CreateDatabaseFromDBHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/CreateDatabaseFromDBHandler.java
@@ -38,9 +38,10 @@ public class CreateDatabaseFromDBHandler extends BaseHMSHandler<CreateDatabaseFr
   public CreateDatabaseFromDBResponse handleRequest(CreateDatabaseFromDBRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Creating database " + request.getDbDesc());
       TDeserializer deserializer = new TDeserializer(getTProtocolFactory());
       Database database = new Database();
@@ -52,8 +53,7 @@ public class CreateDatabaseFromDBHandler extends BaseHMSHandler<CreateDatabaseFr
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/CreateDatabaseHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/CreateDatabaseHandler.java
@@ -36,9 +36,10 @@ public class CreateDatabaseHandler extends BaseHMSHandler<CreateDatabaseRequest,
   public CreateDatabaseResponse handleRequest(CreateDatabaseRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Creating database " + request.getName());
       boolean successful = client.createDatabase(request.getName(), request.getDescription(),
           request.getLocation(), request.getParams());
@@ -48,8 +49,7 @@ public class CreateDatabaseHandler extends BaseHMSHandler<CreateDatabaseRequest,
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/CreatePartitionHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/CreatePartitionHandler.java
@@ -42,9 +42,10 @@ public class CreatePartitionHandler extends BaseHMSHandler<CreatePartitionReques
   public CreatePartitionResponse handleRequest(CreatePartitionRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Creating table with desc: " + request.getTableDesc());
       TDeserializer deserializer = new TDeserializer(getTProtocolFactory());
       Table table = new Table();
@@ -59,8 +60,7 @@ public class CreatePartitionHandler extends BaseHMSHandler<CreatePartitionReques
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/CreateTableHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/CreateTableHandler.java
@@ -38,9 +38,10 @@ public class CreateTableHandler extends BaseHMSHandler<CreateTableRequest, Creat
   public CreateTableResponse handleRequest(CreateTableRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Creating table with desc: " + request.getTableDesc());
       TDeserializer deserializer = new TDeserializer(getTProtocolFactory());
       Table table = new Table();
@@ -52,8 +53,7 @@ public class CreateTableHandler extends BaseHMSHandler<CreateTableRequest, Creat
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/DbExistsHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/DbExistsHandler.java
@@ -36,9 +36,10 @@ public class DbExistsHandler extends BaseHMSHandler<DbExistsRequest, DbExistsRes
   public DbExistsResponse handleRequest(DbExistsRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Checking if " + request.getDbName() + " exists");
       boolean exists = client.dbExists(request.getDbName());
       context.getLogger().log("DB exists: " + exists);
@@ -47,8 +48,7 @@ public class DbExistsHandler extends BaseHMSHandler<DbExistsRequest, DbExistsRes
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/DropDatabaseHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/DropDatabaseHandler.java
@@ -36,9 +36,10 @@ public class DropDatabaseHandler extends BaseHMSHandler<DropDatabaseRequest, Dro
   public DropDatabaseResponse handleRequest(DropDatabaseRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Dropping DB " + request.getDbName());
       boolean successful = client.dropDatabase(request.getDbName(), request.isDeleteData(), request.isCascade());
       context.getLogger().log("Dropped DB: " + successful);
@@ -47,8 +48,7 @@ public class DropDatabaseHandler extends BaseHMSHandler<DropDatabaseRequest, Dro
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/DropPartitionHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/DropPartitionHandler.java
@@ -36,9 +36,10 @@ public class DropPartitionHandler extends BaseHMSHandler<DropPartitionRequest, D
   public DropPartitionResponse handleRequest(DropPartitionRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Dropping partition for table " + request.getTableName() + " in DB " + request.getDbName());
       boolean successful = client.dropPartition(request.getDbName(), request.getTableName(), request.getArguments());
       context.getLogger().log("Dropped partition for table " + request.getTableName() + " in DB " + request.getDbName());
@@ -47,8 +48,7 @@ public class DropPartitionHandler extends BaseHMSHandler<DropPartitionRequest, D
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/DropPartitionsHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/DropPartitionsHandler.java
@@ -40,9 +40,10 @@ public class DropPartitionsHandler extends BaseHMSHandler<DropPartitionsRequest,
   public DropPartitionsResponse handleRequest(DropPartitionsRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Dropping partitions for DB " + request.getDbName() + " table " + request.getTableName());
       DropPartitionsResult result = client.dropPartitions(request.getDbName(), request.getTableName(), request.getPartNames());
       context.getLogger().log("Dropped partitions: " + result);
@@ -54,8 +55,7 @@ public class DropPartitionsHandler extends BaseHMSHandler<DropPartitionsRequest,
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/DropTableHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/DropTableHandler.java
@@ -36,9 +36,10 @@ public class DropTableHandler extends BaseHMSHandler<DropTableRequest, DropTable
   public DropTableResponse handleRequest(DropTableRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Dropping table " + request.getTableName() + " in DB " + request.getDbName());
       boolean successful = client.dropTable(request.getDbName(), request.getTableName());
       context.getLogger().log("Dropped table: " + successful);
@@ -47,8 +48,7 @@ public class DropTableHandler extends BaseHMSHandler<DropTableRequest, DropTable
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetDatabaseHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetDatabaseHandler.java
@@ -40,9 +40,10 @@ public class GetDatabaseHandler extends BaseHMSHandler<GetDatabaseRequest, GetDa
   public GetDatabaseResponse handleRequest(GetDatabaseRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Fetching DB: " + request.getDbName());
       Database database = client.getDatabase(request.getDbName());
       context.getLogger().log("Fetched DB: " + database);
@@ -54,8 +55,7 @@ public class GetDatabaseHandler extends BaseHMSHandler<GetDatabaseRequest, GetDa
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetDatabaseNamesHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetDatabaseNamesHandler.java
@@ -38,9 +38,10 @@ public class GetDatabaseNamesHandler extends BaseHMSHandler<GetDatabaseNamesRequ
   public GetDatabaseNamesResponse handleRequest(GetDatabaseNamesRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Fetching all database names with filter: " + request.getFilter());
       Set<String> databases = client.getDatabaseNames(request.getFilter());
       context.getLogger().log("Fetched database names: " + (databases == null || databases.isEmpty() ? 0 : databases.size()));
@@ -49,8 +50,7 @@ public class GetDatabaseNamesHandler extends BaseHMSHandler<GetDatabaseNamesRequ
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetDatabasesHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetDatabasesHandler.java
@@ -42,9 +42,10 @@ public class GetDatabasesHandler extends BaseHMSHandler<GetDatabasesRequest, Get
   public GetDatabasesResponse handleRequest(GetDatabasesRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Fetching all database objects with filter: " + request.getFilter());
       List<Database> databases = client.getDatabases(request.getFilter());
       context.getLogger().log("Fetched databases: " + (databases == null || databases.isEmpty() ? 0 : databases.size()));
@@ -60,8 +61,7 @@ public class GetDatabasesHandler extends BaseHMSHandler<GetDatabasesRequest, Get
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetPartitionNamesHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetPartitionNamesHandler.java
@@ -38,9 +38,10 @@ public class GetPartitionNamesHandler extends BaseHMSHandler<GetPartitionNamesRe
   public GetPartitionNamesResponse handleRequest(GetPartitionNamesRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Fetching partition Names for DB: " + request.getDbName() + ", table: " + request.getTableName());
       List<String> partitionNameList =
           client.getPartitionNames(request.getDbName(), request.getTableName(), request.getMaxSize());
@@ -52,8 +53,7 @@ public class GetPartitionNamesHandler extends BaseHMSHandler<GetPartitionNamesRe
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetPartitionsByNamesHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetPartitionsByNamesHandler.java
@@ -42,9 +42,10 @@ public class GetPartitionsByNamesHandler extends BaseHMSHandler<GetPartitionsByN
   public GetPartitionsByNamesResponse handleRequest(GetPartitionsByNamesRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Fetching partitions for DB: " + request.getDbName() + ", table: " + request.getTableName());
       List<Partition> partitionList =
           client.getPartitionsByNames(request.getDbName(), request.getTableName(), request.getNames());
@@ -61,8 +62,7 @@ public class GetPartitionsByNamesHandler extends BaseHMSHandler<GetPartitionsByN
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetPartitionsHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetPartitionsHandler.java
@@ -42,9 +42,10 @@ public class GetPartitionsHandler extends BaseHMSHandler<GetPartitionsRequest, G
   public GetPartitionsResponse handleRequest(GetPartitionsRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Fetching partitions for DB: " + request.getDbName() + ", table: " + request.getTableName());
       List<Partition> partitionList;
       if (request.getPartitionExpression() != null) {
@@ -67,8 +68,7 @@ public class GetPartitionsHandler extends BaseHMSHandler<GetPartitionsRequest, G
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetTableHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetTableHandler.java
@@ -40,9 +40,10 @@ public class GetTableHandler extends BaseHMSHandler<GetTableRequest, GetTableRes
   public GetTableResponse handleRequest(GetTableRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Fetching table " + request.getTableName() + " in DB: " + request.getDbName());
       Table table = client.getTable(request.getDbName(), request.getTableName());
       context.getLogger().log("Fetched table: " + request.getTableName());
@@ -54,8 +55,7 @@ public class GetTableHandler extends BaseHMSHandler<GetTableRequest, GetTableRes
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetTableNamesHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetTableNamesHandler.java
@@ -38,9 +38,10 @@ public class GetTableNamesHandler extends BaseHMSHandler<GetTableNamesRequest, G
   public GetTableNamesResponse handleRequest(GetTableNamesRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Fetching all table names for DB: " + request.getDbName() + " with filter: " + request.getFilter());
       Set<String> tables = client.getTableNames(request.getDbName(), request.getFilter());
       context.getLogger().log("Fetched table names: " + (tables == null || tables.isEmpty() ? 0 : tables.size()));
@@ -49,8 +50,7 @@ public class GetTableNamesHandler extends BaseHMSHandler<GetTableNamesRequest, G
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetTablesHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/GetTablesHandler.java
@@ -42,9 +42,10 @@ public class GetTablesHandler extends BaseHMSHandler<GetTablesRequest, GetTables
   public GetTablesResponse handleRequest(GetTablesRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Fetching tables for DB: " + request.getDbName());
       List<Table> tables = client.getTablesByNames(request.getDbName(), request.getTableNames());
       context.getLogger().log("Fetched tables: " + (tables == null || tables.isEmpty() ? 0 : tables.size()));
@@ -60,8 +61,7 @@ public class GetTablesHandler extends BaseHMSHandler<GetTablesRequest, GetTables
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/ListDatabasesHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/ListDatabasesHandler.java
@@ -73,9 +73,10 @@ public class ListDatabasesHandler extends BaseHMSHandler<ListDatabasesRequest, L
   public ListDatabasesResponse handleRequest(ListDatabasesRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       ListDatabasesResponse response = new ListDatabasesResponse();
       DatabasePaginator paginator = new DatabasePaginator(context, request, client);
       PaginatedResponse<Database> paginatedResponse = paginator.paginateByNames(request.getNextToken(), request.getMaxSize());
@@ -100,8 +101,7 @@ public class ListDatabasesHandler extends BaseHMSHandler<ListDatabasesRequest, L
       throw e;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/ListPartitionsByExprHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/ListPartitionsByExprHandler.java
@@ -42,9 +42,10 @@ public class ListPartitionsByExprHandler extends BaseHMSHandler<PartitionsByExpr
     public PartitionsByExprResponse handleRequest(PartitionsByExprRequest request, Context context)
     {
         HiveMetaStoreConf conf = getConf();
+        HiveMetaStoreClient client = null;
         try {
             context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-            HiveMetaStoreClient client = getClient();
+            client = getClient();
 
             List<Partition> partitions = new ArrayList<Partition>();
             boolean hasUnKnownPartitions = client.listPartitionsByExpr(request.getDbName(), request.getTableName(), request.getExpr(),
@@ -69,8 +70,7 @@ public class ListPartitionsByExprHandler extends BaseHMSHandler<PartitionsByExpr
             return response;
         }
         catch (Exception e) {
-            context.getLogger().log("Exception: " + e.getMessage());
-            throw new RuntimeException(e);
+            throw handleException(context, e);
         }
     }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/ListPartitionsHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/ListPartitionsHandler.java
@@ -74,9 +74,10 @@ public class ListPartitionsHandler extends BaseHMSHandler<ListPartitionsRequest,
   public ListPartitionsResponse handleRequest(ListPartitionsRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       ListPartitionsResponse response = new ListPartitionsResponse();
       PartitionPaginator paginator = new PartitionPaginator(context, request, client);
       PaginatedResponse<Partition> paginatedResponse = paginator.paginateByNames(request.getNextToken(), request.getMaxSize());
@@ -96,13 +97,8 @@ public class ListPartitionsHandler extends BaseHMSHandler<ListPartitionsRequest,
       }
       return response;
     }
-    catch (RuntimeException e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw e;
-    }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/ListTablesHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/ListTablesHandler.java
@@ -74,9 +74,10 @@ public class ListTablesHandler extends BaseHMSHandler<ListTablesRequest, ListTab
   public ListTablesResponse handleRequest(ListTablesRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       ListTablesResponse response = new ListTablesResponse();
       TablePaginator paginator = new TablePaginator(context, request, client);
       PaginatedResponse<Table> paginatedResponse = paginator.paginateByNames(request.getNextToken(), request.getMaxSize());
@@ -96,13 +97,8 @@ public class ListTablesHandler extends BaseHMSHandler<ListTablesRequest, ListTab
       }
       return response;
     }
-    catch (RuntimeException e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw e;
-    }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/RenamePartitionHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/RenamePartitionHandler.java
@@ -38,13 +38,14 @@ public class RenamePartitionHandler extends BaseHMSHandler<RenamePartitionReques
     public RenamePartitionResponse handleRequest(RenamePartitionRequest request, Context context)
     {
         HiveMetaStoreConf conf = getConf();
+        HiveMetaStoreClient client = null;
         try {
             if (request.getPartitionDesc() == null || request.getPartitionDesc().length() == 0) {
                 context.getLogger().log("Rename partition: New Partition definition is missing");
                 return new RenamePartitionResponse().setSuccessful(false);
             }
             context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-            HiveMetaStoreClient client = getClient();
+            client = getClient();
             TDeserializer deserializer = new TDeserializer(getTProtocolFactory());
             Partition partition = new Partition();
             deserializer.fromString(partition, request.getPartitionDesc());
@@ -54,8 +55,7 @@ public class RenamePartitionHandler extends BaseHMSHandler<RenamePartitionReques
             return new RenamePartitionResponse().setSuccessful(true);
         }
         catch (Exception e) {
-            context.getLogger().log("Exception: " + e.getMessage());
-            throw new RuntimeException(e);
+            throw handleException(context, e);
         }
     }
 }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/TableExistsHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/TableExistsHandler.java
@@ -36,9 +36,10 @@ public class TableExistsHandler extends BaseHMSHandler<TableExistsRequest, Table
   public TableExistsResponse handleRequest(TableExistsRequest request, Context context)
   {
     HiveMetaStoreConf conf = getConf();
+    HiveMetaStoreClient client = null;
     try {
       context.getLogger().log("Connecting to HMS: " + conf.getMetastoreUri());
-      HiveMetaStoreClient client = getClient();
+      client = getClient();
       context.getLogger().log("Checking if " + request.getDbName() + "." + request.getTableName() + " exists");
       boolean exists = client.tableExists(request.getDbName(), request.getTableName());
       context.getLogger().log("Table exists: " + exists);
@@ -47,8 +48,7 @@ public class TableExistsHandler extends BaseHMSHandler<TableExistsRequest, Table
       return response;
     }
     catch (Exception e) {
-      context.getLogger().log("Exception: " + e.getMessage());
-      throw new RuntimeException(e);
+      throw handleException(context, e);
     }
   }
 }


### PR DESCRIPTION
Customer reported running into Thrift java.net.SocketException: Broken pipe while trying to run queries in below scenarios -

Hive Server becomes unavailable : server is stopped or restarted while running queries
Some partitions contain invalid characters such as a nonvisible space. This causes the API response to fail
Hive becomes unresponsive - i.e max threads are hit on the server causing the APIs to be throttled or delayed
Steps to reproduce the issue are below -

Created EMR cluster and Lambda following https://w.amazon.com/bin/view/AmazonAthena/teams/Compiler/Runbook/CreateHiveMetasoreOnEMR/
Create a data source corresponding to lambda function
Ran query successfully (ID: 1039b960-e525-484e-8db4-ea037e8e4630)
SSH into EMR cluster master node and ran "sudo systemctl stop hive-hcatalog-server"
Ran the same query but received the following error: HIVE_METASTORE_ERROR: com.fasterxml.jackson.databind.JsonMappingException: Unexpected IOException (of type java.io.IOException): java.lang.RuntimeException: org.apache.thrift.transport.TTransportException This query ran against the "default" database, unless qualified by the query. Please post the error message on our forum or contact customer support with Query Id: cd3bdd46-1fa4-44a6-b882-bf1ab198edc1

ran "sudo systemctl start hive-hcatalog-server" inside EMR cluster master node

Ran the same query again but received the following error: HIVE_METASTORE_ERROR: com.fasterxml.jackson.databind.JsonMappingException: Unexpected IOException (of type java.io.IOException): java.lang.RuntimeException: org.apache.thrift.transport.TTransportException: java.net.SocketException: Broken pipe (Write failed) This query ran against the "default" database, unless qualified by the query. Please post the error message on our forum or contact customer support with Query Id: fd93edfe-3a95-4afe-8efb-60696b3fbe27

All retries from this point failed with the same error. Updating a config within the Lambda to "refresh" it allowed queries to succeed again. (ID: 2f40bd72-0e6e-4055-9a1b-0543cc587d3d)

Testing
Below cases were tested by uploading lambda function target jar file from feature/test branch to lambda function in personal account -

Case 1:

Run a sample query against the data source and default database successfully
SSH into EMR cluster master node and ran "sudo systemctl stop hive-hcatalog-server"
Click Refresh button present in athena console just above Data Source on left hand side
Get exception - Failed to create Hive Metastore Client
SSH into EMR cluster master node and ran "sudo systemctl start hive-hcatalog-server"
Click Refresh button present in athena console just above Data Source on left hand side
Run a sample query against the data source and default database successfully again
Case 2:

Run a sample query against the data source and default database successfully
SSH into EMR cluster master node and ran "sudo systemctl stop hive-hcatalog-server"
Click Refresh button present in athena console just above Data Source on left hand side
Get exception - Failed to fetch metadata due to java.lang.RuntimeException: org.apache.thrift.transport.TTransportException
SSH into EMR cluster master node and ran "sudo systemctl start hive-hcatalog-server"
Click Refresh button present in athena console just above Data Source on left hand side
Run a sample query against the data source and default database successfully again
Case 3:

Added a delay of 3 mins to handler for Show Tables in a database
Uploaded jar file to lambda function after building the package
Ran 4 Show Tables Queries from athena console in parallel
SSH into EMR cluster master node and ran netstat -an | grep "9083" to confirm states and actions associated with TCP.
From output of above command, selected one of the established tcp connection and ran below -

ss -K dst 172.31.31.207 dport = 36661

Confirmed that 1 query (https://athena-opsconsole.us-west-2.amazonaws.com/#query_execution:7bcbe2fc-dfec-485d-865b-c28fd819901b) failed in athena console and others succeeded.
Confirmed that client was shutdown due to this exception and new client was created. Reran the query and it succeeds.
Added Thread name details as well in the logs to confirm that right thread is refreshing the client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
