### PR TITLE
Updating AWS Java SDK to match between dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <hive.version>2.3.9</hive.version>
     <hadoop.version>3.2.4</hadoop.version>
     <commons-cli.version>1.4</commons-cli.version>
+    <aws-sdk.version>1.12.261</aws-sdk.version>
   </properties>
 
   <organization>
@@ -48,7 +49,7 @@
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-bom</artifactId>
-        <version>1.11.156</version>
+        <version>${aws-sdk.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -60,17 +61,17 @@
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-core</artifactId>
-        <version>1.11.156</version>
+        <version>${aws-sdk.version}</version>
       </dependency>
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-lambda</artifactId>
-        <version>1.11.156</version>
+        <version>${aws-sdk.version}</version>
       </dependency>
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-s3</artifactId>
-        <version>1.12.261</version>
+        <version>${aws-sdk.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.htrace</groupId>


### PR DESCRIPTION
AWS Java SDK mismatch between S3 and other dependencies can cause an error while publishing partition spill to the S3 location. 

Update the AWS SDK version to match between dependencies


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
